### PR TITLE
ci(circleci): expo requires node 10 - fix for ci fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2
 jobs:
-  test_node_8:
+  test_node_10:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
     steps:
       - checkout
       - run: yarn install --frozen-lockfile
@@ -10,7 +10,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
     steps:
       - checkout
       - run: yarn install --frozen-lockfile
@@ -23,7 +23,7 @@ workflows:
   test_and_release:
     # Run the test jobs first, then the release only when all the test jobs are successful
     jobs:
-      - test_node_8
+      - test_node_10
       - release:
           requires:
-            - test_node_8
+            - test_node_10


### PR DESCRIPTION
CI failed with error about requiring Node 10 for an Expo dep. This should fix.